### PR TITLE
ENT-3375 Added Django admin page for refreshing course skills

### DIFF
--- a/taxonomy/forms.py
+++ b/taxonomy/forms.py
@@ -1,0 +1,9 @@
+"""Taxonomy Forms."""
+from django import forms
+
+
+class RefreshCourseSkillsForm(forms.Form):
+    """Form for the RefreshCourseSkills admin."""
+
+    course_uuid = forms.UUIDField(label='Course UUID:', required=True,
+                                  widget=forms.TextInput(attrs={'class': 'v-text-field'}))

--- a/taxonomy/templates/taxonomy/refresh_course_skills.html
+++ b/taxonomy/templates/taxonomy/refresh_course_skills.html
@@ -1,0 +1,40 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block title %}Taxonomy{% endblock %}
+
+{% block branding %}
+    <h1 id="site-name">'Taxonomy Administration'</h1>
+{% endblock %}
+
+{% block nav-global %}
+    <style type="text/css">
+        .v-text-field {
+            width: 300px;
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    <div id="content-main">
+        <form class="form" method="post" action=".">
+            {% csrf_token %}
+            <div>
+                <span> {{ form.course_uuid.label }}</span>
+                {{ form.course_uuid }}
+            </div>
+            {% block submit_buttons_bottom %}
+                <div class="submit-row">
+                    <input type="submit" value="{% trans 'Update Course Skills' as tmsg %}{{ tmsg | force_escape }}"
+                           class="default" name="_save"/>
+                </div>
+                {% for field, error in form.errors.items %}
+                    {{ error  }}
+                {% endfor %}
+
+            {% endblock %}
+        </form>
+    </div>
+
+{% endblock %}
+

--- a/taxonomy/urls.py
+++ b/taxonomy/urls.py
@@ -1,0 +1,12 @@
+"""
+Taxonomy Service URL Configuration.
+"""
+
+from django.urls import re_path
+
+from taxonomy import views
+
+urlpatterns = [
+    re_path(r"^admin/taxonomy/refresh_course_skills/$", views.RefreshCourseSkills.as_view(),
+            name="refresh_course_skills"),
+]

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -2,3 +2,52 @@
 """
 Django views for taxonomy application.
 """
+from django.contrib import messages
+from django.core import management
+from django.core.exceptions import PermissionDenied
+from django.core.management.base import CommandError
+from django.shortcuts import render
+from django.views.generic import TemplateView
+
+from taxonomy.forms import RefreshCourseSkillsForm
+
+
+class RefreshCourseSkills(TemplateView):
+    """
+    Create/Update Course Skills View.
+    """
+
+    template_name = "taxonomy/refresh_course_skills.html"
+
+    def get_context_data(self, **kwargs):
+        """Return the context data needed to render the view."""
+        if self.request.user.is_authenticated and self.request.user.is_staff:
+            context = super(RefreshCourseSkills, self).get_context_data(**kwargs)
+            context.update({
+                'form': RefreshCourseSkillsForm(),
+            })
+            return context
+        raise PermissionDenied()
+
+    def post(self, request):
+        """
+        Process the form.
+        """
+        form = RefreshCourseSkillsForm(request.POST)
+        if form.is_valid():
+            course_uuid = form.cleaned_data['course_uuid']
+            self._update_course_skills(course_uuid)
+        return render(request, self.template_name, {"form": form})
+
+    def _update_course_skills(self, course_uuid):
+        """
+        Call the management command to refresh data.
+        """
+        try:
+            management.call_command('refresh_course_skills', '--course', course_uuid, '--commit')
+            message = ('Skills data for course_key: {} is updated.'.format(course_uuid))
+            messages.add_message(self.request, messages.SUCCESS, message)
+        except CommandError as error:
+            messages.add_message(self.request, messages.ERROR, error)
+        except Exception as error:  # pylint: disable=broad-except
+            messages.add_message(self.request, messages.ERROR, error)

--- a/test_settings.py
+++ b/test_settings.py
@@ -30,6 +30,8 @@ DATABASES = {
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
     'taxonomy',
 )
 
@@ -37,7 +39,7 @@ LOCALE_PATHS = [
     root('taxonomy', 'conf', 'locale'),
 ]
 
-# ROOT_URLCONF = 'taxonomy.urls'
+ROOT_URLCONF = 'taxonomy.urls'
 
 SECRET_KEY = 'insecure-secret-key'
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,31 @@
+""" Tests for the `taxonomy` Forms module. """
+
+from django.test import TestCase
+
+from taxonomy.forms import RefreshCourseSkillsForm
+
+
+class RefreshCourseSkillsFormTest(TestCase):
+    """Tests for RefreshCourseSkillsForm."""
+
+    def test_with_valid_course_uuid(self):
+        """
+        Test happy path with course_uuid
+        """
+        data = {
+            'course_uuid': ' a6f9804d-76e7-4a2f-85d8-46ca1a096f0f',
+        }
+        form = RefreshCourseSkillsForm(data=data)
+        assert form.is_valid()
+        self.assertDictEqual(form.errors, {})
+
+    def test_with_invalid_course_uuid(self):
+        """
+        Test for form errors.
+        """
+        data = {
+            'course_uuid': '',
+        }
+        form = RefreshCourseSkillsForm(data=data)
+        assert not form.is_valid()
+        self.assertDictEqual(form.errors, {'course_uuid': ['This field is required.']})

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,18 @@
+"""
+Tests for the `taxonomy` url module.
+"""
+from unittest import TestCase
+
+from django.urls import resolve
+
+from taxonomy.views import RefreshCourseSkills
+
+
+class TestUrls(TestCase):
+    """
+    Functional url Tests for RefreshCourseSkills.
+    """
+
+    def test_home_url_resolves_home_view(self):
+        view = resolve('/admin/taxonomy/refresh_course_skills/')
+        self.assertEqual(view.func.view_class, RefreshCourseSkills)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,193 @@
+"""
+Tests for the `taxonomy` views module.
+"""
+import mock
+
+from django.contrib import messages
+from django.contrib.auth.models import AnonymousUser, User
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory, TestCase
+
+from taxonomy.views import RefreshCourseSkills
+from test_utils.mocks import MockCourse
+from test_utils.providers import DiscoveryCourseMetadataProvider
+from test_utils.sample_responses.skills import SKILLS
+
+
+class RefreshCourseSkillsTest(TestCase):
+    """
+    Functional Tests for RefreshCourseSkills Page.
+    """
+
+    def setUp(self):
+        # Every test needs access to the request factory.
+        super(RefreshCourseSkillsTest, self).setUp()
+        self.request = RequestFactory().post('/')
+        self.user = User.objects.create_user(
+            username="edx",
+            is_staff=True, is_superuser=True
+        )
+
+    def test_form_set_in_context(self):
+        """
+        Test that the form is available to html template through context.
+        """
+        self.request.user = self.user
+        view = RefreshCourseSkills()
+        view.setup(self.request)
+
+        context = view.get_context_data()
+        self.assertIn('course_uuid', context['form'].fields)
+
+    def test_raise_permission_denied_for_non_staff_user(self):
+        """
+        Test that the only staff and admin user has access to this view.
+        """
+        user = self.user
+        user.is_staff = False
+        self.request.user = user
+        view = RefreshCourseSkills()
+        view.setup(self.request)
+        with self.assertRaises(PermissionDenied):
+            view.get_context_data()
+
+    def test_raise_permission_denied_for_anonymous_user(self):
+        """
+        Test the validation for anonymous users.
+        """
+        user = AnonymousUser()
+        self.request.user = user
+        view = RefreshCourseSkills()
+        view.setup(self.request)
+        with self.assertRaises(PermissionDenied):
+            view.get_context_data()
+
+    @mock.patch('taxonomy.views.RefreshCourseSkills._update_course_skills')
+    @mock.patch('taxonomy.views.render')
+    def test_form_post(self, get_course_skills_mock, mock_render):
+        """
+        Test the data in form on post request.
+        """
+        request = self.request
+        course_uuid = 'a6f9804d-76e7-4a2f-85d8-46ca1a096f0f'
+        request.user = self.user
+        get_course_skills_mock.return_value = {}
+        request.POST = {'course_uuid': course_uuid}
+        view = RefreshCourseSkills()
+        view.setup(request)
+        view.post(request)
+        self.assertIn(course_uuid, mock_render.call_args[0][0].urn)
+
+    @mock.patch('taxonomy.views.RefreshCourseSkills._update_course_skills')
+    @mock.patch('taxonomy.views.render')
+    def test_form_post_empty_data(self, get_course_skills_mock, mock_render):
+        """
+        Test the empty data in form on post request.
+        """
+        request = self.request
+        course_uuid = ''
+        request.user = self.user
+        get_course_skills_mock.return_value = {}
+        request.POST = {'course_uuid': course_uuid}
+        view = RefreshCourseSkills()
+        view.setup(request)
+        view.post(request)
+        self.assertEqual(mock_render.call_args, None)
+
+    @mock.patch('taxonomy.management.commands.refresh_course_skills.get_course_metadata_provider')
+    @mock.patch('taxonomy.management.commands.refresh_course_skills.EMSISkillsApiClient.get_course_skills')
+    def test_update_course_skill(self, get_course_skills_mock, get_course_provider_mock):
+        """
+        Test that the course skills are updated on passing valid course uuid.
+        """
+        request = self.request
+        # Annotate a request object with a session
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+
+        # Annotate a request object with a messages
+        middleware = MessageMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+
+        get_course_skills_mock.return_value = SKILLS
+        course = MockCourse()
+        get_course_provider_mock.return_value = DiscoveryCourseMetadataProvider([course])
+        request.user = self.user
+        view = RefreshCourseSkills()
+        view.setup(request)
+        view._update_course_skills(course.uuid)  # pylint: disable=protected-access
+
+        msg = ('Skills data for course_key: {} is updated.'.format(course.uuid))
+        msg_tag = 'success'
+        storage = messages.get_messages(request)
+        for message in storage:
+            self.assertEqual(msg, message.message)
+            self.assertEqual(msg_tag, message.tags)
+
+    @mock.patch('taxonomy.management.commands.refresh_course_skills.get_course_metadata_provider')
+    def test_update_course_skill_failed(self, get_course_provider_mock):
+        """
+        Test that the course skills updation failed and exception is raised.
+        """
+        request = self.request
+
+        # Annotate a request object with a session
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+
+        # Annotate a request object with a messages
+        middleware = MessageMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+        msg = 'Exception with Taxonomy Service.'
+
+        get_course_provider_mock.side_effect = Exception(msg)
+
+        request.user = self.user
+        view = RefreshCourseSkills()
+        view.setup(request)
+
+        view._update_course_skills("uuid")  # pylint: disable=protected-access
+        msg_tag = 'error'
+        storage = messages.get_messages(request)
+        for message in storage:
+            self.assertIn(msg, message.message.args)
+            self.assertEqual(msg_tag, message.tags)
+
+    @mock.patch('taxonomy.management.commands.refresh_course_skills.get_course_metadata_provider')
+    @mock.patch('taxonomy.management.commands.refresh_course_skills.EMSISkillsApiClient.get_course_skills')
+    def test_update_course_skill_failed_unknown_uuid(self, get_course_skills_mock, get_course_provider_mock):
+        """
+        Test that the course skills updation failed on passing
+         invalid or empty course uuid and command error is raised.
+        """
+        request = self.request
+
+        # Annotate a request object with a session
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+
+        # Annotate a request object with a messages
+        middleware = MessageMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+
+        get_course_provider_mock.return_value = DiscoveryCourseMetadataProvider([])
+        get_course_skills_mock.return_value = SKILLS
+        request.user = self.user
+        view = RefreshCourseSkills()
+        view.setup(request)
+
+        view._update_course_skills("uuid")  # pylint: disable=protected-access
+        msg = 'No courses found. Did you specify an argument?'
+        msg_tag = 'error'
+        storage = messages.get_messages(request)
+        for message in storage:
+            self.assertIn(msg, message.message.args)
+            self.assertEqual(msg_tag, message.tags)


### PR DESCRIPTION
Django Tool: Call API to refresh a single course's course-skill data

**Testing Scenario:**

1. Please check this PR.

2. Please Navigate to [Course Discovery Page](http://localhost:18381/admin/taxonomy/refresh_course_skills/)

3. Please enter a valid course UUID and course skills will be updated at [Course Skills](http://localhost:18381/admin/taxonomy/courseskills/)

