### PR TITLE
ENT-3428: Include package data, so that migrations and python packages are included in the final build.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Unreleased
 --------------------
 
 
+[1.0.1] - 2020-09-21
+--------------------
+
+* Added package data, so that migrations and python packages are included in the final build.
+
 [1.0.0] - 2020-09-09
 --------------------
 

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,8 @@ setup(
     version=VERSION,
     packages=[
         'taxonomy',
-        'taxonomy.providers',
-        'taxonomy.validators',
     ],
+    include_package_data=True,
     description='Taxonomy service',
     long_description=README + "\n\n" + CHANGELOG,
     author='edX',

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -3,6 +3,6 @@
 Your project description goes here.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
__Description:__
This PR makes sure that migrations and python packages are included in the final build.